### PR TITLE
added role redhat-satellite-quickstart

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "redhat-satellite-quickstart"]
+	path = redhat-satellite-quickstart
+	url = https://github.com/flyemsafe/redhat-satellite-quickstart.git


### PR DESCRIPTION
This roles configures a fresh or existing Satellite to be ready for day-two use. This role was added using git submodules.