### PR TITLE
Remove python2-apypie dependency in install role

### DIFF
--- a/roles/install/tasks/2_theforeman.yml
+++ b/roles/install/tasks/2_theforeman.yml
@@ -1,9 +1,0 @@
-- name: theforeman | copy python2 apypie rpm file to server
-  copy:
-     src: "{{ satellite_apypie_rpm }}"
-     dest: "/tmp/{{ satellite_apypie_rpm }}"
-
-- name: theforeman | install python2 apypie rpm
-  yum:
-     name: "/tmp/{{ satellite_apypie_rpm }}"
-     state: present

--- a/roles/install/tasks/main.yml
+++ b/roles/install/tasks/main.yml
@@ -2,9 +2,6 @@
 - name: main | config firewalld
   import_tasks: 1_firewalld.yml
 
-- name: main | install theforeman prereq
-  import_tasks: 2_theforeman.yml
-  
 - name: main | Create Custom Certs
   import_tasks: 3.5_prep-custom-certs.yml
   when: satellite_CSR == 'true'

--- a/roles/install/vars/main.yml
+++ b/roles/install/vars/main.yml
@@ -1,6 +1,5 @@
 satellite_packages:
   - satellite
-  - python2-apypie
   - chrony
   - sos
 

--- a/roles/install/vars/main.yml
+++ b/roles/install/vars/main.yml
@@ -1,7 +1,7 @@
 satellite_packages:
   - satellite
+  - python2-apypie
   - chrony
   - sos
 
 satellite_fw_service_name: RH-Satellite-6
-satellite_apypie_rpm: "python2-apypie-0.2.1-2.el7.noarch.rpm"


### PR DESCRIPTION
The install role expects `python2-apypie-0.2.1-2.el7.noarch.rpm` to exist in `files/`, but there is no need to install python2-apypie from a local file since it's part of the satellite repo.
This patch adds python2-apypie to `satellite_packages` instead.