### PR TITLE
Add configuration stuff we're missing

### DIFF
--- a/roles/config_missing/defaults/main.yml
+++ b/roles/config_missing/defaults/main.yml
@@ -1,0 +1,65 @@
+satellite_state: present
+
+# satellite_organizations:
+#   - name: Org1
+
+# satellite_locations:
+#   - name: Loc1
+#     organizations:
+#       - Org1
+
+# satellite_repository_sets:
+#   - organization: "{{ satellite_organization }}"
+#     label: rhel-7-server-rpms
+#     repositories:
+#       - releasever: 7Server
+#         basearch: x86_64
+#   - organization: "{{ satellite_organization }}"
+#     label: rhel-7-server-kickstart
+#     repositories:
+#       - releasever: "7.7"
+#         basearch: x86_64
+#       - releasever: "7.8"
+#         basearch: x86_64
+#       - releasever: "7.9"
+#         basearch: x86_64
+#   - organization: "{{ satellite_organization }}"
+#     label: rhel-7-server-ansible-2.8-rpms
+#     all_repositories: true
+
+# satellite_content_view_versions:
+#   - organization: "{{ satellite_organization }}"
+#     content_view: capsule
+#     version: 1.0
+
+# satellite_sync_plans:
+#   - organization: "{{ satellite_organization }}"
+#     name: RHEL
+#     description: RHEL Repos Only
+#     enabled: true
+#     interval: daily
+#     sync_date: 2020-03-31 00:00:00 UTC
+#     products:
+#       - Red Hat Enterprise Linux for x86_64
+#       - Red Hat Enterprise Linux Server
+#   - organization: "{{ satellite_organization }}"
+#     name: RH_Products
+#     description: All Red Hat Products except RHEL
+#     enabled: true
+#     interval: daily
+#     sync_date: 2020-03-31 01:00:00 UTC
+#     products:
+#       - Red Hat Ansible Engine
+#       - Red Hat Ceph Storage
+#       - Red Hat Ceph Storage MON
+#       - Red Hat Ceph Storage OSD
+#       - Red Hat Enterprise Linux Advanced Virtualization
+#       - Red Hat Enterprise Linux Fast Datapath
+#       - Red Hat Enterprise Linux High Availability for x86_64
+#       - Red Hat OpenStack
+#       - Red Hat Satellite Capsule
+#       - Red Hat Software Collections (for RHEL Server)
+
+# satellite_settings:
+#   - name: template_sync_repo
+#     value: https://example.com/satellite-templates.git

--- a/roles/config_missing/tasks/main.yml
+++ b/roles/config_missing/tasks/main.yml
@@ -1,0 +1,77 @@
+---
+- name: configure organizations
+  theforeman.foreman.organization:
+    username: "{{ satellite_admin_username }}"
+    password: "{{ satellite_admin_password }}"
+    server_url: "{{ satellite_server_url }}"
+    name: "{{ item.name }}"
+    state: "{{ satellite_state }}"
+  loop: "{{ satellite_organizations }}"
+  when: satellite_organizations is defined
+
+- name: configure locations
+  theforeman.foreman.location:
+    username: "{{ satellite_admin_username }}"
+    password: "{{ satellite_admin_password }}"
+    server_url: "{{ satellite_server_url }}"
+    name: "{{ item.name }}"
+    organizations: "{{ item.organizations }}"
+    state: "{{ satellite_state }}"
+  loop: "{{ satellite_locations }}"
+  when: satellite_locations is defined
+
+- name: configure repository sets
+  theforeman.foreman.repository_set:
+    username: "{{ satellite_admin_username }}"
+    password: "{{ satellite_admin_password }}"
+    server_url: "{{ satellite_server_url }}"
+    organization: "{{ item.organization }}"
+    label: "{{ item.label }}"
+    all_repositories: "{{ item.all_repositories | default(omit) }}"
+    repositories: "{{ item.repositories | default(omit) }}"
+    state: "{{ item.state | default('enabled') }}"
+  loop: "{{ satellite_repository_sets }}"
+  when: satellite_repository_sets is defined
+
+- name: configure content view versions
+  theforeman.foreman.content_view_version:
+    username: "{{ satellite_admin_username }}"
+    password: "{{ satellite_admin_password }}"
+    server_url: "{{ satellite_server_url }}"
+    organization: "{{ item.organization }}"
+    content_view: "{{ item.content_view }}"
+    current_lifecycle_environment: "{{ item.current_lifecycle_environment | default(omit) }}"
+    description: "{{ item.description | default(omit) }}"
+    force_promote: "{{ item.force_promote | default(omit) }}"
+    force_yum_metadata_regeneration: "{{ item.force_yum_metadata_regeneration | default(omit) }}"
+    lifecycle_environments: "{{ item.lifecycle_environments | default(omit) }}"
+    version: "{{ item.version | default(omit) }}"
+  loop: "{{ satellite_content_view_versions }}"
+  when: satellite_content_view_versions is defined
+
+- name: configure sync plans
+  theforeman.foreman.sync_plan:
+    username: "{{ satellite_admin_username }}"
+    password: "{{ satellite_admin_password }}"
+    server_url: "{{ satellite_server_url }}"
+    organization: "{{ item.organization }}"
+    name: "{{ item.name }}"
+    cron_expression: "{{ item.cron_expression | default(omit) }}"
+    description: "{{ item.description | default(omit) }}"
+    enabled: "{{ item.enabled }}"
+    interval: "{{ item.interval }}"
+    products: "{{ item.products | default(omit) }}"
+    state: "{{ item.state | default('present') }}"
+    sync_date: "{{ item.sync_date }}"
+  loop: "{{ satellite_sync_plans }}"
+  when: satellite_sync_plans is defined
+
+- name: configure settings
+  theforeman.foreman.setting:
+    username: "{{ satellite_admin_username }}"
+    password: "{{ satellite_admin_password }}"
+    server_url: "{{ satellite_server_url }}"
+    name: "{{ item.name }}"
+    value: "{{ item.value }}"
+  loop: "{{ satellite_settings }}"
+  when: satellite_settings is defined


### PR DESCRIPTION
this is the stuff I'm missing to move to this collection completely, all in the spirit of the existing config role

I'd merge this into the existing config role first and refactor from there, as the existing role could use some, like it's a do-it-all mix of working from both global and per-organization perspective, so e.g. the per-organization parts could be separated and allow to be called repeatedly