### PR TITLE
wrong repo name

### DIFF
--- a/roles/rhsm/tasks/4_enable_repo.yml
+++ b/roles/rhsm/tasks/4_enable_repo.yml
@@ -9,7 +9,7 @@
     name: 
       - rhel-{{ ansible_distribution_major_version }}-server-rpms
       - rhel-{{ ansible_distribution_major_version }}-server-satellite-{{ satellite_version }}-rpms
-      - rhel-server-rhscl-server-{{ ansible_distribution_major_version }}-rpms
+      - rhel-server-rhscl-{{ ansible_distribution_major_version }}-rpms
       - rhel-{{ ansible_distribution_major_version }}-server-satellite-maintenance-6-rpms
       - rhel-{{ ansible_distribution_major_version }}-server-ansible-2.8-rpms
     state: enabled


### PR DESCRIPTION
FAILED! => {"changed": false, "msg": "rhel-server-rhscl-server-7-rpms is not a valid repository ID"